### PR TITLE
Show screen names in the user activity feed

### DIFF
--- a/app/admin/dashboard/users/[id]/page.tsx
+++ b/app/admin/dashboard/users/[id]/page.tsx
@@ -16,6 +16,7 @@ import {
   Inbox,
 } from "lucide-react";
 import { adminFetch } from "@/lib/admin-api";
+import { describeEvent, eventLabel } from "@/lib/analytics-events";
 import {
   AiConversationModal,
   type AiConversation,
@@ -193,7 +194,7 @@ export default function UserDetailPage() {
                         key={s.label}
                         className="rounded-full bg-gray-100 px-2.5 py-1 text-xs font-medium text-gray-700"
                       >
-                        {s.label} · {s.value}
+                        {eventLabel(s.label)} · {s.value}
                       </span>
                     ))}
                   </div>
@@ -201,8 +202,7 @@ export default function UserDetailPage() {
                     {data.activity.recent.map((e, i) => (
                       <div key={i} className="flex justify-between gap-2">
                         <span className="truncate">
-                          {e.event_name}
-                          {e.properties?.title ? ` · ${e.properties.title}` : ""}
+                          {describeEvent(e.event_name, e.properties)}
                         </span>
                         <span className="shrink-0 text-gray-400">{dt(e.created_at)}</span>
                       </div>

--- a/lib/analytics-events.ts
+++ b/lib/analytics-events.ts
@@ -1,0 +1,122 @@
+/**
+ * Human-readable labels for rows of `analytics_events`.
+ *
+ * The app logs a bare event name plus a small `properties` bag (see
+ * `AnalyticsService` in the Flutter app). Rendering only the event name makes
+ * the activity feed useless — every `screen_view` looks identical — so map the
+ * name to a label and pull the one property that actually identifies the row.
+ */
+
+/** Router paths emitted by `screen_view` → the screen a user would recognise. */
+const SCREEN_LABELS: Record<string, string> = {
+  "/": "Home",
+  "/login": "Login",
+  "/splash": "Splash",
+  "/onboarding": "Onboarding",
+  "/dashboard": "Dashboard",
+  "/downloads": "Downloads",
+  "/ai-chat": "AI Chat",
+  "/ai/ask": "AI Ask",
+  "/chat": "Chat",
+  "/courses": "Courses",
+  "/settings": "Settings",
+  "/syllabus": "Syllabus",
+  "/notes": "Notes",
+  "/entrance": "Entrance",
+  "/loksewa": "Loksewa",
+  "/youtube": "YouTube",
+  "/extra": "Extra",
+  "/notifications": "Notifications",
+  "/noticesandresults": "Notices & Results",
+  "/scrollableMotivation": "Motivation",
+  "/bookmarks": "Bookmarks",
+  "/quiz": "Quiz",
+  "/study-timer": "Study Timer",
+  // Screens opened with Navigator.push (see `analyticsRoute` in the app).
+  "/pdf-viewer": "PDF Viewer",
+  "/page": "Content Page",
+  "/ai-chat/settings": "AI Chat Settings",
+  "/chat/image-upload": "Chat Image Upload",
+  "/courses/folder": "Course Folder",
+  "/courses/playlist": "Course Playlist",
+  "/courses/video": "Course Video",
+  "/courses/youtube-sign-in": "YouTube Sign-in",
+  "/downloads/pdf": "Downloaded PDF",
+  "/loksewa/web": "Loksewa Link",
+  "/notes/course-wizard": "Notes Course Picker",
+  "/notes/document": "Note Document",
+  "/noticesandresults/pdf": "Notice PDF",
+  "/noticesandresults/variant": "Notice Province",
+  "/quiz/play": "Quiz",
+  "/quiz/result": "Quiz Result",
+  "/settings/contact-us": "Contact Us",
+  "/settings/feedback": "Feedback",
+  "/settings/privacy-policy": "Privacy Policy",
+  "/settings/about-us": "About Us",
+  "/syllabus/pdf": "Syllabus PDF",
+  "/syllabus/program-pdf": "Program Syllabus PDF",
+};
+
+const EVENT_LABELS: Record<string, string> = {
+  app_open: "App opened",
+  login: "Logged in",
+  sign_up: "Signed up",
+  sign_out: "Signed out",
+  screen_view: "Viewed",
+  onboarding_start: "Onboarding started",
+  onboarding_step: "Onboarding step",
+  onboarding_complete: "Onboarding complete",
+  whatsapp_optin: "WhatsApp opt-in",
+  share: "Shared",
+  download: "Downloaded",
+  quiz_complete: "Quiz completed",
+};
+
+export function screenLabel(screen: string): string {
+  // Strip query strings so `/notes?id=3` still resolves to a known screen.
+  const path = screen.split("?")[0];
+  if (SCREEN_LABELS[path]) return SCREEN_LABELS[path];
+  const known = Object.keys(SCREEN_LABELS)
+    .filter((p) => p !== "/" && path.startsWith(`${p}/`))
+    .sort((a, b) => b.length - a.length)[0];
+  return known ? `${SCREEN_LABELS[known]} · ${path.slice(known.length + 1)}` : path;
+}
+
+export function eventLabel(eventName: string): string {
+  return EVENT_LABELS[eventName] ?? eventName.replace(/_/g, " ");
+}
+
+/** The detail that distinguishes one row of an event from another, if any. */
+export function eventDetail(
+  eventName: string,
+  properties: Record<string, any> | null | undefined,
+): string | null {
+  const p = properties ?? {};
+  switch (eventName) {
+    case "screen_view":
+      return typeof p.screen === "string" ? screenLabel(p.screen) : null;
+    case "login":
+    case "sign_up":
+      return p.method ?? null;
+    case "onboarding_step":
+      return p.step ?? null;
+    case "share":
+      return p.surface ?? null;
+    case "quiz_complete":
+      return [p.quiz_id, p.score != null ? `score ${p.score}` : null]
+        .filter(Boolean)
+        .join(" · ") || null;
+    default:
+      return p.title ?? p.name ?? null;
+  }
+}
+
+/** One-line summary of an event row, e.g. `Viewed · Notices & Results`. */
+export function describeEvent(
+  eventName: string,
+  properties: Record<string, any> | null | undefined,
+): string {
+  const detail = eventDetail(eventName, properties);
+  const label = eventLabel(eventName);
+  return detail ? `${label} · ${detail}` : label;
+}


### PR DESCRIPTION
## Problem

The admin user-detail activity feed rendered only `event_name` plus `properties.title`. `screen_view` never carries a `title`, so a session looked like this:

```
screen_view   3:12:35 PM
screen_view   3:11:59 PM
app_open      3:10:50 PM
share         3:08:56 PM
```

Every navigation collapsed to the same word. The screen was never missing from the data — the app has always logged `screen_view {screen: '/notes'}` — the UI just wasn't reading it.

## Change

- New `lib/analytics-events.ts`: event-name labels, router-path to screen-name map (with prefix matching for sub-routes and query strings stripped), and per-event detail extraction (`screen`, `method`, `step`, `surface`, quiz id/score, else `title`).
- `app/admin/dashboard/users/[id]/page.tsx` renders `describeEvent(...)`; summary chips use `eventLabel`.

Same feed now:

```
Viewed - Notices & Results   3:12:35 PM
Viewed - Home                3:11:59 PM
App opened                   3:10:50 PM
Shared - app                 3:08:56 PM
Onboarding step - district   3:07:48 PM
```

Unknown paths and unknown event names fall through to the raw value, so nothing disappears if the app adds a screen before this map is updated.

## Related

Pairs with jeevankoiri10/ctevt_plus_flutter_app — screens opened via `Navigator.push` weren't logging `screen_view` at all; the labels for those paths are already in the map here.

## Testing

`npx tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)